### PR TITLE
add missing device assignment

### DIFF
--- a/performer_pytorch/performer_pytorch.py
+++ b/performer_pytorch/performer_pytorch.py
@@ -150,7 +150,7 @@ class FastAttention(nn.Module):
         self.kernel_fn = kernel_fn
 
         if not redraw_projection:
-            self.set_projection_matrix()
+            self.set_projection_matrix('cpu')
 
         self.causal = causal
         if causal:


### PR DESCRIPTION
device parameter is missing when redraw_projection=False is used. By default the device can be assigned to 'cpu'.

Since projection matrix is assign to the module buffer, it will be tied to the same device memory as the module is.

The script below can be used to reproduce the error and validate the fix

```
from performer_pytorch import FastAttention
import torch

if __name__ == '__main__':

    q, k, v = torch.randn(10, 100, 10, 32), torch.randn(10, 100, 10, 32) , torch.randn(10, 100, 10, 32)
    print('cpu with no redraw')
    fast_attention = FastAttention(32, redraw_projection=False)
    fast_attention(q, k, v)

    fast_attention.cuda()
    print('gpu with no redraw')
    fast_attention(q.cuda(), k.cuda(), v.cuda())
```