### PR TITLE
Added fixed and axial positional embedding option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     'local-attention>=1.1.1',
     'pytorch-fast-transformers>=0.3.0',
     'torch>=1.6',
+    'axial-positional-embedding>=0.1.0'
   ],
   classifiers=[
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
Hello Phil, 

this PR adds fixed and axial positional embedding support as discussed in #47. Code is similar to reformer implementation, but the fixed pos_embs are computed once.

I was kinda busy so I looked at it now, have a nice 2021!