### PR TITLE
Allow for performers to be used on cpu-only torch

### DIFF
--- a/performer_pytorch/performer_pytorch.py
+++ b/performer_pytorch/performer_pytorch.py
@@ -2,7 +2,6 @@ import math
 import torch
 import torch.nn.functional as F
 from torch import nn
-from torch.cuda.amp import autocast
 from einops import rearrange, repeat
 
 from functools import partial
@@ -11,6 +10,11 @@ from contextlib import contextmanager
 from local_attention import LocalAttention
 from axial_positional_embedding import AxialPositionalEmbedding
 from performer_pytorch.reversible import ReversibleSequence, SequentialSequence
+
+try:
+    from torch.cuda.amp import autocast
+except:
+    pass
 
 try:
     from apex import amp

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     'einops>=0.3',
     'local-attention>=1.1.1',
     'pytorch-fast-transformers>=0.3.0',
-    'torch>=1.6',
+    'torch>=1.4',
     'axial-positional-embedding>=0.1.0'
   ],
   classifiers=[


### PR DESCRIPTION
This PR resolves an issue I had using the performer on cpu-only torch where it failed to import the missing cuda components.

Tested with `pip3 install torch==1.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html`
