### PR TITLE
Fix torch.qr deprecation warning

### DIFF
--- a/performer_pytorch/performer_pytorch.py
+++ b/performer_pytorch/performer_pytorch.py
@@ -12,6 +12,10 @@ from local_attention import LocalAttention
 from axial_positional_embedding import AxialPositionalEmbedding
 from performer_pytorch.reversible import ReversibleSequence, SequentialSequence
 
+from distutils.version import LooseVersion
+
+TORCH_GE_1_8_0 = LooseVersion(torch.__version__) >= LooseVersion('1.8.0')
+
 try:
     from apex import amp
     APEX_AVAILABLE = True
@@ -128,7 +132,10 @@ def generalized_kernel(data, *, projection_matrix, kernel_fn = nn.ReLU(), kernel
 
 def orthogonal_matrix_chunk(cols, device = None):
     unstructured_block = torch.randn((cols, cols), device = device)
-    q, r = torch.qr(unstructured_block.cpu(), some = True)
+    if TORCH_GE_1_8_0:
+        q, r = torch.linalg.qr(unstructured_block.cpu(), mode = 'reduced')
+    else:
+        q, r = torch.qr(unstructured_block.cpu(), some = True)
     q, r = map(lambda t: t.to(device), (q, r))
     return q.t()
 


### PR DESCRIPTION
When training with a performer I get the following warning:

```python
torch.qr is deprecated in favor of torch.linalg.qr and will be removed in a future PyTorch release.
The boolean parameter 'some' has been replaced with a string parameter 'mode'.
Q, R = torch.qr(A, some)
should be replaced with
Q, R = torch.linalg.qr(A, 'reduced' if some else 'complete') (Triggered internally at  /pytorch/aten/src/ATen/native/BatchLinearAlgebra.cpp:1940.)
```

This patch fixes it by conditionally switching to the new invocation, while maintaining backwards compatibility.