### PR TITLE
Add repetition penalty for text generation

### DIFF
--- a/performer_pytorch/autoregressive_wrapper.py
+++ b/performer_pytorch/autoregressive_wrapper.py
@@ -41,7 +41,7 @@ class AutoregressiveWrapper(nn.Module):
         self.max_seq_len = net.max_seq_len
 
     @torch.no_grad()
-    def generate(self, start_tokens, seq_len, eos_token = None, temperature = 1., filter_logits_fn = top_k, filter_thres = 0.9, repetition_penalty=1.0, repetition_penalty_ctx=32 **kwargs):
+    def generate(self, start_tokens, seq_len, eos_token = None, temperature = 1., filter_logits_fn = top_k, filter_thres = 0.9, repetition_penalty=1.0, repetition_penalty_ctx=32, **kwargs):
         was_training = self.net.training
         num_dims = len(start_tokens.shape)
 


### PR DESCRIPTION
Implement repetition penalty when generating with autoregressive models.

The original method is described in [CTRL paper](https://arxiv.org/pdf/1909.05858.pdf)
Added the ability to provide the size of the context window (instead of the whole generated sequence) to allow repetition after a few words (normal for long texts)